### PR TITLE
fix prysm rpc provider & gateway flags

### DIFF
--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -14,8 +14,13 @@ SIGNER_API_URL=$(get_signer_api_url "${NETWORK}" "${SUPPORTED_NETWORKS}")
 BEACON_API_URL=$(get_beacon_api_url "${NETWORK}" "${SUPPORTED_NETWORKS}" "${CLIENT}")
 MEVBOOST_FLAG=$(get_mevboost_flag "${MEVBOOST_FLAG_KEY}" "${SKIP_MEVBOOST_URL}")
 
-# Extract the hostname from BEACON_API_URL and append port 4000
-BEACON_API_4000="$(echo "$BEACON_API_URL" | cut -d'/' -f3 | cut -d':' -f1):4000"
+# Extract base URL. This assumes BEACON_API_URL will has the following format: http://<domain>:<port> 
+# Example: http://localhost:4000 -> localhost
+BASE_URL="$(echo "$BEACON_API_URL" | cut -d'/' -f3 | cut -d':' -f1)"
+
+# Prepare API endpoints (no http:// prefix && add port)
+BEACON_API_4000="${BASE_URL}:4000"
+BEACON_API_GATEWAY_PROVIDER="${BASE_URL}:3500"
 
 case "$NETWORK" in
 "holesky")
@@ -44,7 +49,7 @@ exec /validator \
     --wallet-dir="${WALLET_DIR}" \
     --monitoring-host 0.0.0.0 \
     --beacon-rpc-provider="${BEACON_API_4000}" \
-    --beacon-rpc-gateway-provider="${BEACON_API_URL}" \
+    --beacon-rpc-gateway-provider="${BEACON_API_GATEWAY_PROVIDER}" \
     --validators-external-signer-url="${SIGNER_API_URL}" \
     --grpc-gateway-host=0.0.0.0 \
     --grpc-gateway-port="${VALIDATOR_API_PORT}" \

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -16,11 +16,11 @@ MEVBOOST_FLAG=$(get_mevboost_flag "${MEVBOOST_FLAG_KEY}" "${SKIP_MEVBOOST_URL}")
 
 # Extract base URL. This assumes BEACON_API_URL will has the following format: http://<domain>:<port> 
 # Example: http://localhost:4000 -> localhost
-BASE_URL="$(echo "$BEACON_API_URL" | cut -d'/' -f3 | cut -d':' -f1)"
+BEACON_DOMAIN="$(echo "$BEACON_API_URL" | cut -d'/' -f3 | cut -d':' -f1)"
 
 # Prepare API endpoints (no http:// prefix && add port)
-BEACON_API_4000="${BASE_URL}:4000"
-BEACON_API_GATEWAY_PROVIDER="${BASE_URL}:3500"
+BEACON_RPC_PROVIDER="${BEACON_DOMAIN}:4000"
+BEACON_RPC_GATEWAY_PROVIDER="${BEACON_DOMAIN}:3500"
 
 case "$NETWORK" in
 "holesky")
@@ -48,8 +48,8 @@ exec /validator \
     --datadir="${DATA_DIR}" \
     --wallet-dir="${WALLET_DIR}" \
     --monitoring-host 0.0.0.0 \
-    --beacon-rpc-provider="${BEACON_API_4000}" \
-    --beacon-rpc-gateway-provider="${BEACON_API_GATEWAY_PROVIDER}" \
+    --beacon-rpc-provider="${BEACON_RPC_PROVIDER}" \
+    --beacon-rpc-gateway-provider="${BEACON_RPC_GATEWAY_PROVIDER}" \
     --validators-external-signer-url="${SIGNER_API_URL}" \
     --grpc-gateway-host=0.0.0.0 \
     --grpc-gateway-port="${VALIDATOR_API_PORT}" \

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -14,7 +14,8 @@ SIGNER_API_URL=$(get_signer_api_url "${NETWORK}" "${SUPPORTED_NETWORKS}")
 BEACON_API_URL=$(get_beacon_api_url "${NETWORK}" "${SUPPORTED_NETWORKS}" "${CLIENT}")
 MEVBOOST_FLAG=$(get_mevboost_flag "${MEVBOOST_FLAG_KEY}" "${SKIP_MEVBOOST_URL}")
 
-BEACON_API_4000="$(echo "$BEACON_API_URL" | cut -d':' -f1,2):4000"
+# Extract the hostname from BEACON_API_URL and append port 4000
+BEACON_API_4000="$(echo "$BEACON_API_URL" | cut -d'/' -f3 | cut -d':' -f1):4000"
 
 case "$NETWORK" in
 "holesky")


### PR DESCRIPTION
fixes error:
`time="2024-07-23 08:14:36" level=warning msg="Could not determine if beacon chain started" error="could not receive ChainStart from stream: could not setup beacon chain ChainStart streaming client: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp: address http://beacon-chain.prysm-holesky.dappnode:4000: too many colons in address": could not connect: could not connect" prefix=client
`

from prysm cli docs:
https://docs.prylabs.network/docs/prysm-usage/parameters#validator-flags
```
--beacon-rest-api-provider value                   Beacon node REST API provider endpoint. (default: "http://127.0.0.1:3500")
--beacon-rpc-gateway-provider value                Beacon node RPC gateway provider endpoint. (default: "127.0.0.1:3500")
--beacon-rpc-provider value                        Beacon node RPC provider endpoint. (default: "127.0.0.1:4000")
```

beacon-rpc-gateway-provider value && beacon-rpc-provider value should not have "http://"
