### PR TITLE
Use upstream 5.0.4

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "prysmaticlabs/prysm",
-      "version": "v5.1.0",
+      "version": "v5.0.4",
       "arg": "UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v5.1.0
+        UPSTREAM_VERSION: v5.0.4
         STAKER_SCRIPTS_VERSION: v0.1.0
         DATA_DIR: /data
     volumes:
@@ -22,7 +22,7 @@ services:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: v5.1.0
+        UPSTREAM_VERSION: v5.0.4
         STAKER_SCRIPTS_VERSION: v0.1.0
         DATA_DIR: /root/.eth2validators
     volumes:


### PR DESCRIPTION
Use `v5.0.4` to prevent the regeneration of the Auth token that implies unauthorized connection from the `brain` service of the Web3Signer package:

```
time="2024-09-26 10:04:15" level=warning msg="You are using an insecure gRPC connection. If you are running your beacon node and validator on the same machines, you can ignore this message. If you want to know how to enable secure connections, see: https://docs.prylabs.network/docs/prysm-usage/secure-grpc" prefix=client
time="2024-09-26 10:04:15" level=warning msg="Auth token is a legacy file and should be regenerated." prefix=rpc
time="2024-09-26 10:04:15" level=warning msg="Auth token does not follow our standards and should be regenerated either 
1. by removing the current token file and restarting 
2. using the `validator web generate-auth-token` command. 
Tokens can be generated through the `validator web generate-auth-token` command" error="invalid auth token: token should be hex-encoded and at least 256 bits" prefix=rpc
time="2024-09-26 10:04:15" level=info msg="Once your validator process is running, navigate to the link below to authenticate with the Prysm web interface" prefix=rpc
time="2024-09-26 10:04:15" level=info msg="http://0.0.0.0:3500/initialize?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.MxwOozSH-TLbW_XKepjyYDHm2IT8Ki0tD3AHuajfNMg" prefix=rpc
time="2024-09-26 10:04:15" level=info msg="Validator Client auth token for gRPC and REST authentication set at /root/.eth2validators/prysm-wallet-v2/auth-token" prefix=rpc
``