### PR TITLE
Fix flags use  `grpc` instead of `http`

### DIFF
--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -52,9 +52,9 @@ FLAGS="--datadir=$DATA_DIR \
     --beacon-rpc-provider=$BEACON_RPC_PROVIDER \
     --beacon-rpc-gateway-provider=$BEACON_RPC_GATEWAY_PROVIDER \
     --validators-external-signer-url=$SIGNER_API_URL \
-    --http-host=0.0.0.0 \
-    --http-port=$VALIDATOR_API_PORT \
-    --http-cors-domain=http://0.0.0.0:$VALIDATOR_API_PORT \
+    --grpc-gateway-host=0.0.0.0 \
+    --grpc-gateway-port=$VALIDATOR_API_PORT \
+    --grpc-gateway-corsdomain=http://0.0.0.0:$VALIDATOR_API_PORT \
     --graffiti=$VALID_GRAFFITI \
     --suggested-fee-recipient=$VALID_FEE_RECIPIENT \
     --verbosity=$VERBOSITY \


### PR DESCRIPTION
Fix flags use  `grpc` instead of `http`