### PR TITLE
Update LUKSO docker-compose

### DIFF
--- a/package_variants/lukso/docker-compose.yml
+++ b/package_variants/lukso/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       CORSDOMAIN: "http://prysm-lukso.dappnode"
       MIN_SYNC_PEERS: "1"
       MAX_PEERS: "70"
-      SUBSCRIBE_ALL_SUBNETS: "true"
+      SUBSCRIBE_ALL_SUBNETS: "false"
   validator:
     build:
       args:


### PR DESCRIPTION
This PR changes subnets flags for Prysm, because of possible OOM Prysm issues (relevant for Prysm v5+).