### PR TITLE
Add upstream to manifest in lukso

### DIFF
--- a/package_variants/lukso/dappnode_package.json
+++ b/package_variants/lukso/dappnode_package.json
@@ -7,6 +7,13 @@
     "readme": "https://github.com/dappnode/DAppNodePackage-prysm-generic",
     "docs": "https://docs.prylabs.network/docs/getting-started"
   },
+  "upstream": [
+    {
+      "repo": "prysmaticlabs/prysm",
+      "version": "v5.0.4",
+      "arg": "UPSTREAM_VERSION"
+    },
+  ],
   "optionalDependencies": {
     "lukso-geth.dnp.dappnode.eth": ">=0.1.3",
     "web3signer-lukso.dnp.dappnode.eth": ">=0.1.3"


### PR DESCRIPTION
Add upstream to manifest in lukso. This is needed to enforce the compose to reflect the upstream version