### PR TITLE
RPC CORS flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Lodestar Dappnode Package
+# Prysm Dappnode Package
 
-**Lodestar ETH2.0 Beacon chain + validator**
+**Prysm ETH2.0 Beacon chain + validator**
 
 Go Ethereum Consensus Layer Implementation by Prysmatic Labs.
 

--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -75,7 +75,8 @@ FLAGS="--accept-terms-of-use \
   --p2p-udp-port=$P2P_UDP_PORT \
   --p2p-max-peers=$MAX_PEERS \
   --min-sync-peers=$MIN_SYNC_PEERS \
-  --subscribe-all-subnets=$SUBSCRIBE_ALL_SUBNETS $NETWORK_FLAGS $CHECKPOINT_SYNC_FLAGS $MEVBOOST_FLAG $EXTRA_OPTS"
+  --subscribe-all-subnets=$SUBSCRIBE_ALL_SUBNETS $NETWORK_FLAGS $CHECKPOINT_SYNC_FLAGS $MEVBOOST_FLAG $EXTRA_OPTS \
+  --grpc-gateway-corsdomain value=*"
 
 echo "[INFO - entrypoint] Starting beacon with flags: $FLAGS"
 

--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -76,7 +76,7 @@ FLAGS="--accept-terms-of-use \
   --p2p-max-peers=$MAX_PEERS \
   --min-sync-peers=$MIN_SYNC_PEERS \
   --subscribe-all-subnets=$SUBSCRIBE_ALL_SUBNETS $NETWORK_FLAGS $CHECKPOINT_SYNC_FLAGS $MEVBOOST_FLAG $EXTRA_OPTS \
-  --grpc-gateway-corsdomain value=*"
+  --grpc-gateway-corsdomain=*"
 
 echo "[INFO - entrypoint] Starting beacon with flags: $FLAGS"
 


### PR DESCRIPTION
Adding the `--grpc-gateway-corsdomain=*` flag to avoid CORS issues when accessing the client RPC in the browser.