### PR TITLE
Add ARM support

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -15,7 +15,7 @@
   "description": "Validate with Prysm: a Go implementation of the Ethereum 2.0 Serenity protocol and open source project created by Prysmatic Labs.\n\nIt includes a Grafana dashboard for the [DMS](http://my.dappnode/#/installer/dms.dnp.dappnode.eth) thanks to the amazing work of [metanull-operator](https://github.com/metanull-operator/eth2-grafana)",
   "type": "service",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
-  "architectures": ["linux/amd64"],
+  "architectures": ["linux/amd64", "linux/arm64"],
   "mainService": "beacon-chain",
   "contributors": [
     "dappLion <dapplion@dappnode.io> (https://github.com/dapplion)"


### PR DESCRIPTION
Base images are already available on ARM so we just need to add arm64 to the architectures field.