### PR TITLE
bump prysmaticlabs/prysm to v7.1.3, dappnode/staker-package-scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "prysmaticlabs/prysm",
-      "version": "v7.1.2",
+      "version": "v7.1.3",
       "arg": "UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v7.1.2
+        UPSTREAM_VERSION: v7.1.3
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /data
     volumes:
@@ -21,7 +21,7 @@ services:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: v7.1.2
+        UPSTREAM_VERSION: v7.1.3
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /root/.eth2validators
     restart: on-failure

--- a/package_variants/hoodi/dappnode_package.json
+++ b/package_variants/hoodi/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "prysm-hoodi.dnp.dappnode.eth",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "links": {
     "ui": "http://brain.web3signer-hoodi.dappnode",
     "homepage": "https://prysmaticlabs.com/",

--- a/package_variants/mainnet/dappnode_package.json
+++ b/package_variants/mainnet/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "prysm.dnp.dappnode.eth",
-  "version": "3.0.25",
+  "version": "3.0.26",
   "links": {
     "ui": "http://brain.web3signer.dappnode",
     "homepage": "https://prysmaticlabs.com/",

--- a/package_variants/sepolia/dappnode_package.json
+++ b/package_variants/sepolia/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "prysm-sepolia.dnp.dappnode.eth",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "links": {
     "homepage": "https://prysmaticlabs.com/",
     "readme": "https://github.com/dappnode/DAppNodePackage-prysm-generic",


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v7.1.2 to [v7.1.3](https://github.com/prysmaticlabs/prysm/releases/tag/v7.1.3)
- [dappnode/staker-package-scripts](https://github.com/dappnode/staker-package-scripts) from v0.1.2 to [v0.1.2](https://github.com/dappnode/staker-package-scripts/releases/tag/v0.1.2)